### PR TITLE
Fix grob name forwarding

### DIFF
--- a/R/textbox-grob.R
+++ b/R/textbox-grob.R
@@ -275,6 +275,7 @@ textbox_grob <- function(text, x = NULL, y = NULL,
     gp = gp,
     box_gp = box_gp,
     vp = vp,
+    name = name,
     cl = "textbox_grob"
   )
 }


### PR DESCRIPTION
forward `name` argument to gTree creation in `textbox_grob()`, addressing issue #13.