### PR TITLE
Solve #24 – use `font` gpar instead of `fontface` to work with R 4.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # gridtext 0.1.4.9000
 
 - Transition to curl package and drop RCurl dependency
+- Fix fontface not being processed and words spaced properly in R 4.2.0
 
 # gridtext 0.1.4
 

--- a/R/drawing-context.R
+++ b/R/drawing-context.R
@@ -46,8 +46,8 @@ set_style <- function(drawing_context, style = NULL) {
 update_gpar <- function(gp, gp_new) {
   names_new <- names(gp_new)
   names_old <- names(gp)
-  gp[c(intersect(names_old, names_new), "font")] <- NULL
-  gp_new["font"] <- NULL
+  gp[c(intersect(names_old, names_new), "fontface")] <- NULL
+  gp_new["fontface"] <- NULL
   do.call(gpar, c(gp, gp_new))
 }
 

--- a/R/drawing-context.R
+++ b/R/drawing-context.R
@@ -70,13 +70,13 @@ set_context_gp <- function(drawing_context, gp = NULL) {
 
 # update the fontface of a drawing context
 set_context_fontface <- function(drawing_context, fontface = "plain", overwrite = FALSE) {
-  fontface_old <- drawing_context$gp$font
+  font_old <- drawing_context$gp$font
 
   # combine bold and italic if needed
   if (!isTRUE(overwrite)) {
-    if (isTRUE(fontface == "italic") && isTRUE(fontface_old == 2)) { # see ?grid::gpar for fontface codes
+    if (isTRUE(fontface == "italic") && isTRUE(font_old == 2)) { # see ?grid::gpar for fontface codes
       fontface <- "bold.italic"
-    } else if (isTRUE(fontface == "bold") && isTRUE(fontface_old == 3)) {
+    } else if (isTRUE(fontface == "bold") && isTRUE(font_old == 3)) {
       fontface <- "bold.italic"
     }
   }

--- a/R/drawing-context.R
+++ b/R/drawing-context.R
@@ -70,13 +70,13 @@ set_context_gp <- function(drawing_context, gp = NULL) {
 
 # update the fontface of a drawing context
 set_context_fontface <- function(drawing_context, fontface = "plain", overwrite = FALSE) {
-  fontface_old <- drawing_context$gp$fontface
+  fontface_old <- drawing_context$gp$font
 
   # combine bold and italic if needed
   if (!isTRUE(overwrite)) {
-    if (isTRUE(fontface == "italic") && isTRUE(fontface_old == "bold")) {
+    if (isTRUE(fontface == "italic") && isTRUE(fontface_old == 2)) { # see ?grid::gpar for fontface codes
       fontface <- "bold.italic"
-    } else if (isTRUE(fontface == "bold") && isTRUE(fontface_old == "italic")) {
+    } else if (isTRUE(fontface == "bold") && isTRUE(fontface_old == 3)) {
       fontface <- "bold.italic"
     }
   }

--- a/R/text-details.R
+++ b/R/text-details.R
@@ -2,23 +2,23 @@
 #'
 #' Calculate text details for a given text label
 #' @param label Character vector containing the label. Can handle only one label at a time.
-#' @param gp Grid graphical parameters defining the font (`fontfamily`, `fontface`, and
-#'   `fontface` should be defined).
+#' @param gp Grid graphical parameters defining the font (`fontfamily`, `font`, and
+#'   `fontsize` should be defined).
 #' @examples
-#' text_details("Hello world!", grid::gpar(fontfamily = "", fontface = "plain", fontsize = 12))
-#' text_details("Hello world!", grid::gpar(fontfamily = "", fontface = "plain", fontsize = 24))
+#' text_details("Hello world!", grid::gpar(fontfamily = "", font = "plain", fontsize = 12))
+#' text_details("Hello world!", grid::gpar(fontfamily = "", font = "plain", fontsize = 24))
 #' text_details(
 #'   "Hello world\nwith newline",
-#'   grid::gpar(fontfamily = "", fontface = "plain", fontsize = 12)
+#'   grid::gpar(fontfamily = "", font = "plain", fontsize = 12)
 #' )
 #' @noRd
 text_details <- function(label, gp = gpar()) {
   fontfamily <- gp$fontfamily %||% grid::get.gpar("fontfamily")$fontfamily
-  fontface <- gp$fontface %||% grid::get.gpar("fontface")$fontface
+  font <- gp$font %||% grid::get.gpar("font")$font
   fontsize <- gp$fontsize %||% grid::get.gpar("fontsize")$fontsize
 
   devname <- names(grDevices::dev.cur())
-  fontkey <- paste0(devname, fontfamily, fontface, fontsize)
+  fontkey <- paste0(devname, fontfamily, font, fontsize)
   if (devname == "null device") {
     cache <- FALSE   # don't cache if no device open
   } else {
@@ -30,16 +30,16 @@ text_details <- function(label, gp = gpar()) {
   }
 
   # ascent and width depend on label and font
-  l1 <- text_info(label, fontkey, fontfamily, fontface, fontsize, cache)
+  l1 <- text_info(label, fontkey, fontfamily, font, fontsize, cache)
   # descent and space width depend only on font
-  l2 <- font_info(fontkey, fontfamily, fontface, fontsize, cache)
+  l2 <- font_info(fontkey, fontfamily, font, fontsize, cache)
 
   # concatenate, result is a list with four members, width_pt, ascent_pt, descent_pt, space_pt
   c(l1, l2)
 }
 
 font_info_cache <- new.env(parent = emptyenv())
-font_info <- function(fontkey, fontfamily, fontface, fontsize, cache) {
+font_info <- function(fontkey, fontfamily, font, fontsize, cache) {
   info <- font_info_cache[[fontkey]]
 
   if (is.null(info)) {
@@ -48,7 +48,7 @@ font_info <- function(fontkey, fontfamily, fontface, fontsize, cache) {
       gp = gpar(
         fontsize = fontsize,
         fontfamily = fontfamily,
-        fontface = fontface,
+        font = font,
         cex = 1
       )
     )), "pt", valueOnly = TRUE)
@@ -58,7 +58,7 @@ font_info <- function(fontkey, fontfamily, fontface, fontsize, cache) {
       gp = gpar(
         fontsize = fontsize,
         fontfamily = fontfamily,
-        fontface = fontface,
+        font = font,
         cex = 1
       )
     )), "pt", valueOnly = TRUE)
@@ -73,7 +73,7 @@ font_info <- function(fontkey, fontfamily, fontface, fontsize, cache) {
 }
 
 text_info_cache <- new.env(parent = emptyenv())
-text_info <- function(label, fontkey, fontfamily, fontface, fontsize, cache) {
+text_info <- function(label, fontkey, fontfamily, font, fontsize, cache) {
   key <- paste0(label, fontkey)
   info <- text_info_cache[[key]]
 
@@ -83,7 +83,7 @@ text_info <- function(label, fontkey, fontfamily, fontface, fontsize, cache) {
       gp = gpar(
         fontsize = fontsize,
         fontfamily = fontfamily,
-        fontface = fontface,
+        font = font,
         cex = 1
       )
     )), "pt", valueOnly = TRUE)
@@ -93,7 +93,7 @@ text_info <- function(label, fontkey, fontfamily, fontface, fontsize, cache) {
       gp = gpar(
         fontsize = fontsize,
         fontfamily = fontfamily,
-        fontface = fontface,
+        font = font,
         cex = 1
       )
     )), "pt", valueOnly = TRUE)

--- a/R/text-details.R
+++ b/R/text-details.R
@@ -2,14 +2,14 @@
 #'
 #' Calculate text details for a given text label
 #' @param label Character vector containing the label. Can handle only one label at a time.
-#' @param gp Grid graphical parameters defining the font (`fontfamily`, `font`, and
+#' @param gp Grid graphical parameters defining the font (`fontfamily`, `fontface`, and
 #'   `fontsize` should be defined).
 #' @examples
-#' text_details("Hello world!", grid::gpar(fontfamily = "", font = "plain", fontsize = 12))
-#' text_details("Hello world!", grid::gpar(fontfamily = "", font = "plain", fontsize = 24))
+#' text_details("Hello world!", grid::gpar(fontfamily = "", fontface = "plain", fontsize = 12))
+#' text_details("Hello world!", grid::gpar(fontfamily = "", fontface = "plain", fontsize = 24))
 #' text_details(
 #'   "Hello world\nwith newline",
-#'   grid::gpar(fontfamily = "", font = "plain", fontsize = 12)
+#'   grid::gpar(fontfamily = "", fontface = "plain", fontsize = 12)
 #' )
 #' @noRd
 text_details <- function(label, gp = gpar()) {


### PR DESCRIPTION
This PR solves https://github.com/wilkelab/gridtext/issues/24 for me. I've checked carefully every `fontface` appearance in the package and fixed the critical places. Note that if you use `fontface` in `gpar()`, it is automatically "translated" to `font` (and `fontface` is discarded) with appropriate integer code, so in those occasions, it could be left intact (I believe this `font`-centered  {grid} behavior will last many years to come).

One special place is in `set_context_fontface()` – this is called only by `process_tags()`, which utilizes character-based `fontface` argument, but it is used as positional argument in every occasion, so it works. The function retrieved face from `drawing_context$gp$fontface`, which was in this PR changed to drawing_context$gp$font and subsequent usage of this retrieved face was edited to work with integer `face` par.

I tested the compatibility with {ggtext}, which also uses `fontface` at its last stage before handed over to {gridtext}. This is again accomplished by passing `fontface` inside `gpar()`, **so it is "translated "correctly even in R 4.2.0**.